### PR TITLE
Fix "fatal: ambiguous argument"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ NEWS_FILE_SLUG="$(date -d ${RELEASE_DATE} '+%d %b %Y'), PHP ${RELEASE_VERSION}"
 sed -i \
     -e "s/?? ??? \(????\|[0-9]\{4\}\),.*/${NEWS_FILE_SLUG}/g" \
     NEWS
-if [ ! -z "$(git diff NEWS)" ]; then
+if [ ! -z "$(git diff -- NEWS)" ]; then
   git add NEWS
   git commit -m "Update NEWS for PHP ${RELEASE_VERSION}"
   git show | cat -


### PR DESCRIPTION
From output

`Switched to a new branch 'PHP-7.2.4' Building 7.2.4RC1 from PHP-7.2.4 fatal: ambiguous argument 'NEWS': both revision and filename Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]'`