### PR TITLE
add GPG_CMD to config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -248,7 +248,7 @@ echo "Tarballs prepared"
 /workspace/bin/manifest.sh "/workspace/php-src/php-$RELEASE_VERSION.tar"
 
 echo "Run the following command in workspace/php-src to sign everything:"
-echo "$ ../bin/sign.sh . '$RELEASE_VERSION' '$TAG_COMMIT' '${GPG_KEY:-YOUR_GPG_KEY}' '${GPG_USER:-$COMMITTER_EMAIL}'"
+echo "$ ../bin/sign.sh . '$RELEASE_VERSION' '$TAG_COMMIT' '${GPG_KEY:-YOUR_GPG_KEY}' '${GPG_USER:-$COMMITTER_EMAIL}' '${GPG_CMD:-gpg}'"
 echo ""
 
 echo "Verify what you're about to push as a tagged release:"

--- a/config.default
+++ b/config.default
@@ -39,6 +39,9 @@ RELEASE_NEXT="7.2.0alpha2"
 ## This value is only used to help produce helpful finalization instructions
 # GPG_KEY="123456789012345678901234"
 
+## command to use to sign the generated tarballs, e.g. /usr/bin/gpg1, /usr/bin/gpg2...
+# GPG_CMD=gpg
+
 ## Set to 0 to allow `run-tests.php` to encounter failures without aborting packaging (optional; default on)
 # ABORT_ON_TEST_FAILURES=1
 

--- a/sign.sh
+++ b/sign.sh
@@ -6,9 +6,10 @@ RELEASE_VERSION=${2:?"Missing Release Version"}
 TAG_COMMIT=${3:?"Missing tag commit"}
 GPG_KEY=${4:?"Missing GPG fingerprint"}
 GPG_USER=${5:?"Missing GPG user"}
+GPG_CMD=${6:-gpg}
 
 for COMP in gz bz2 xz; do
-	GPG_TTY=${GPG_TTY:-$(tty)} gpg -u "${GPG_USER}" --armor --detach-sign "${PHP_SRC}/php-${RELEASE_VERSION}.tar.$COMP"
+	GPG_TTY=${GPG_TTY:-$(tty)} $GPG_CMD -u "${GPG_USER}" --armor --detach-sign "${PHP_SRC}/php-${RELEASE_VERSION}.tar.$COMP"
 done
 GPG_TTY=${GPG_TTY:-$(tty)} git tag -u "${GPG_KEY}" "php-${RELEASE_VERSION}" -m "Tag for php ${RELEASE_VERSION}" "$TAG_COMMIT"
 


### PR DESCRIPTION
To be able to use something else than "`gpg`" and avoid having to fix sign.sh on each release
(I have to use `/usr/bin/gpg1` as `gpg` = `gpg2` is broken for me, unable to find the keys)